### PR TITLE
Handrevert

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -169,8 +169,6 @@ void configure_request(xcb_generic_event_t *evt)
 		apply_size_hints(c, &width, &height);
 		c->floating_rectangle.width = width;
 		c->floating_rectangle.height = height;
-		c->floating_rectangle.x -= c->border_width;
-		c->floating_rectangle.y -= c->border_width;
 		xcb_rectangle_t r = c->floating_rectangle;
 
 		window_move_resize(e->window, r.x, r.y, r.width, r.height);

--- a/src/tree.c
+++ b/src/tree.c
@@ -122,8 +122,6 @@ void apply_layout(monitor_t *m, desktop_t *d, node_t *n, xcb_rectangle_t rect, x
 		/* floating clients */
 		} else if (s == STATE_FLOATING) {
 			r = n->client->floating_rectangle;
-			r.x -= n->client->border_width;
-			r.y -= n->client->border_width;
 		/* fullscreen clients */
 		} else {
 			r = m->rectangle;


### PR DESCRIPTION
remove 1456 and related changes.
behavior is bugged, and i'd rather xcb_get_geometry and config window coordinates matched.